### PR TITLE
Utilisation d'un lambda pour la contrainte de région dans les routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
 
   localized do
     # La contrainte ressemble à `region_slug: /(occitanie|ile-de-france)/`
-    scope "(:region_slug)", constraints: { region_slug: Regexp.new(Region.pluck(:slug).join("|")) } do 
+    scope "(:region_slug)", constraints: lambda { |req| Region.pluck(:slug).include?(req.params[:region_slug]) } do
       resources :materials, only: [:index, :show] do
         collection do
           get ':item_slug/:option_slug' => 'materials#option', as: :option

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,6 @@ Rails.application.routes.draw do
   draw 'admin'
 
   localized do
-    # La contrainte ressemble à `region_slug: /(occitanie|ile-de-france)/`
     scope "(:region_slug)", constraints: lambda { |req| Region.pluck(:slug).include?(req.params[:region_slug]) } do
       resources :materials, only: [:index, :show] do
         collection do


### PR DESCRIPTION
Ça évite l'interprétation de `Region.pluck(:slug)` dans un contexte où la DB ne contient pas la table `regions` (exemple : le setup de l'app)