### PR TITLE
removed description from first link in toolbox menu

### DIFF
--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -51,13 +51,10 @@ page_lab = Page.lab
               <%= t('menu.primary.toolbox') %>
             </a>
             <ul class="dropdown-menu dropdown-menu--toolbox col-md-12 p-0">
-              <% page_toolbox.children.ordered_by_position.each_with_index do |page, index| %>
+              <% page_toolbox.children.ordered_by_position.each do |page| %>
                 <li>
                 <%= link_to page, class: "dropdown-item dropdown-item--ecosystem py-2" do %>
                   <b><%= sanitize page.name %></b>
-                  <% if index === 0 %>
-                    <%= sanitize page.description %>
-                  <% end %>
                 <% end %>
                 </li>
               <% end %>


### PR DESCRIPTION
Suppression du texte dans le menu de la boîte à outils : 

![image](https://github.com/user-attachments/assets/49c10fdc-0bad-42d0-bbe0-5df7d7b85cc4)

On laisse le vert (?) pour le moment :
![Capture d’écran 2025-06-10 à 10 25 21](https://github.com/user-attachments/assets/3cbb2f91-feb1-4434-a929-592d37743d1f)
